### PR TITLE
Added Provider-Specific timeouts

### DIFF
--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -48,7 +48,7 @@ class Client(QObject):
 
     def __init__(self,
                  provider=None,
-                 retry_timeout=60):
+                 retry_timeout=None):
         """
         :param provider: A openrouteservice provider from config.yml
         :type provider: dict
@@ -64,9 +64,15 @@ class Client(QObject):
         self.ENV_VARS = provider.get('ENV_VARS')
         
         # self.session = requests.Session()
-        self.nam = networkaccessmanager.NetworkAccessManager(debug=False)
+        if retry_timeout is None:
+            try:
+                retry_timeout = int(provider['timeout'])
+            except Exception:
+                retry_timeout = 60
+        
+        self.nam = networkaccessmanager.NetworkAccessManager(debug=False, timeout=retry_timeout)
 
-        self.retry_timeout = timedelta(seconds=retry_timeout)
+        self.retry_timeout = timedelta(seconds=int(retry_timeout))
         self.headers = {
                 "User-Agent": _USER_AGENT,
                 'Content-type': 'application/json',

--- a/ORStools/common/networkaccessmanager.py
+++ b/ORStools/common/networkaccessmanager.py
@@ -142,7 +142,7 @@ class NetworkAccessManager(object):
             'exception' - the exception returne dduring execution
     """
 
-    def __init__(self, authid=None, disable_ssl_certificate_validation=False, exception_class=None, debug=True):
+    def __init__(self, authid=None, disable_ssl_certificate_validation=False, exception_class=None, debug=True, timeout=None):
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
         self.authid = authid
         self.reply = None
@@ -160,6 +160,9 @@ class NetworkAccessManager(object):
             'reason': '',
             'exception': None,
         })
+        if timeout is None:
+            timeout=60
+        self.timeout=timeout
 
     def msg_log(self, msg):
         if self.debug:
@@ -227,8 +230,10 @@ class NetworkAccessManager(object):
         if self.authid:
             self.msg_log("Update reply w/ authid: {0}".format(self.authid))
             self.auth_manager().updateNetworkReply(self.reply, self.authid)
+        
+        QgsNetworkAccessManager.instance().setTimeout(int(self.timeout)*1000)
 
-        # necessary to trap local timout manage by QgsNetworkAccessManager
+        # necessary to trap local timeout manage by QgsNetworkAccessManager
         # calling QgsNetworkAccessManager::abortRequest
         QgsNetworkAccessManager.instance().requestTimedOut.connect(self.requestTimedOut)
 

--- a/ORStools/config.yml
+++ b/ORStools/config.yml
@@ -2,6 +2,7 @@ providers:
 - ENV_VARS:
     ORS_QUOTA: X-Ratelimit-Limit
     ORS_REMAINING: X-Ratelimit-Remaining
-  base_url: https://api.openrouteservice.org
-  key:
+  base_url: https://ors.germany.new.ils-geomonitoring.de
+  key: ''
   name: openrouteservice
+  timeout: 480

--- a/ORStools/config.yml
+++ b/ORStools/config.yml
@@ -2,7 +2,7 @@ providers:
 - ENV_VARS:
     ORS_QUOTA: X-Ratelimit-Limit
     ORS_REMAINING: X-Ratelimit-Remaining
-  base_url: https://ors.germany.new.ils-geomonitoring.de
+  base_url: https://api.openrouteservice.org
   key: ''
   name: openrouteservice
-  timeout: 480
+  timeout: 60


### PR DESCRIPTION
For calculation of big Matrixes on our custom ORS-Server I needed more calculation time, so I included a new provider-specific timeout for orstools-qgis-plugin.

It is still a little bit ugly as I use some unnecessary recasting int/string for seconds-values...