### PR TITLE
update profiles and preferences

### DIFF
--- a/ORStools/common/__init__.py
+++ b/ORStools/common/__init__.py
@@ -32,7 +32,6 @@ PROFILES = [
             'driving-hgv',
             'cycling-regular',
             'cycling-road',
-            'cycling-safe',
             'cycling-mountain',
             'cycling-electric',
             'foot-walking',
@@ -42,4 +41,4 @@ PROFILES = [
 
 DIMENSIONS = ['time', 'distance']
 
-PREFERENCES = ['fastest', 'shortest']
+PREFERENCES = ['fastest', 'shortest', 'recommended']

--- a/ORStools/common/directions_core.py
+++ b/ORStools/common/directions_core.py
@@ -124,7 +124,7 @@ def get_output_feature_directions(response, profile, preference, options=None, f
     :param profile: Transportation mode being used
     :type profile: str
 
-    :param preference: Cost being used, shortest or fastest.
+    :param preference: Cost being used, shortest, fastest or recommended.
     :type preference: str
 
     :param options: Avoidables being used.

--- a/ORStools/proc/directions_lines_proc.py
+++ b/ORStools/proc/directions_lines_proc.py
@@ -291,7 +291,7 @@ class ORSdirectionsLinesAlgo(QgsProcessingAlgorithm):
         :param profile: transport profile to be used
         :type profile: str
 
-        :param preference: routing preference, shortest/fastest
+        :param preference: routing preference, shortest/fastest/recommended
         :type preference: str
 
         :returns: parameters for optimization endpoint

--- a/ORStools/proc/directions_points_layer_proc.py
+++ b/ORStools/proc/directions_points_layer_proc.py
@@ -281,7 +281,7 @@ class ORSdirectionsPointsLayerAlgo(QgsProcessingAlgorithm):
         :param profile: transport profile to be used
         :type profile: str
 
-        :param preference: routing preference, shortest/fastest
+        :param preference: routing preference, shortest/fastest/recommended
         :type preference: str
 
         :returns: parameters for optimization endpoint


### PR DESCRIPTION
The "cycling-safe"-profile has been removed from the openrouteservice.
The "recommended" routing preference is available via the API, thus the
QGIS plugin should include it, too.

The latter change was provided by @pankus, but the PR was too old to merge easily.