### PR TITLE
Compute isochrones from scratch layer w/o fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ RELEASING:
 ### Fixed
 - author information
 - repository link
+- Correct isochrone computation from layer without fields
 
 ### Removed
 - 'cycling-safe' profile


### PR DESCRIPTION
Temporary scratch layers can be created without fields, so looking up
the first field will fail. In this case, there is no `id_field` and the
defaults for isochrones.set_parameters() will be used - compare
isochrones_point_proc.