### PR TITLE
Add provider-specific timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ RELEASING:
 - isochrone center lat and lon to isochrone attribute table ([#137](https://github.com/GIScience/orstools-qgis-plugin/issues/137))
 - implement `options`-parameter for routing and isochrones
 - prepare `options`-parameter for matrix
+- custom request timeouts for providers ([#122](https://github.com/GIScience/orstools-qgis-plugin/issues/122))
 
 ## [1.4.0] - 2021-06-15
 

--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -46,9 +46,7 @@ _USER_AGENT = f"ORSQGISClient@v{__version__}"
 class Client(QObject):
     """Performs requests to the ORS API services."""
 
-    def __init__(self,
-                 provider=None,
-                 retry_timeout=60):
+    def __init__(self, provider=None):
         """
         :param provider: A openrouteservice provider from config.yml
         :type provider: dict
@@ -64,7 +62,9 @@ class Client(QObject):
         self.ENV_VARS = provider.get('ENV_VARS')
 
         # self.session = requests.Session()
-        self.nam = networkaccessmanager.NetworkAccessManager(debug=False)
+        retry_timeout = provider.get('timeout')
+
+        self.nam = networkaccessmanager.NetworkAccessManager(debug=False, timeout=retry_timeout)
 
         self.retry_timeout = timedelta(seconds=retry_timeout)
         self.headers = {

--- a/ORStools/common/networkaccessmanager.py
+++ b/ORStools/common/networkaccessmanager.py
@@ -142,7 +142,7 @@ class NetworkAccessManager(object):
             'exception' - the exception returned during execution
     """
 
-    def __init__(self, authid=None, disable_ssl_certificate_validation=False, exception_class=None, debug=True):
+    def __init__(self, authid=None, disable_ssl_certificate_validation=False, exception_class=None, debug=True, timeout=60):
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
         self.authid = authid
         self.reply = None
@@ -160,6 +160,7 @@ class NetworkAccessManager(object):
             'reason': '',
             'exception': None,
         })
+        self.timeout=timeout
 
     def msg_log(self, msg):
         if self.debug:
@@ -227,8 +228,10 @@ class NetworkAccessManager(object):
         if self.authid:
             self.msg_log(f"Update reply w/ authid: {self.authid}")
             self.auth_manager().updateNetworkReply(self.reply, self.authid)
+        
+        QgsNetworkAccessManager.instance().setTimeout(self.timeout*1000)
 
-        # necessary to trap local timout manage by QgsNetworkAccessManager
+        # necessary to trap local timeout managed by QgsNetworkAccessManager
         # calling QgsNetworkAccessManager::abortRequest
         QgsNetworkAccessManager.instance().requestTimedOut.connect(self.requestTimedOut)
 

--- a/ORStools/config.yml
+++ b/ORStools/config.yml
@@ -3,5 +3,6 @@ providers:
     ORS_QUOTA: X-Ratelimit-Limit
     ORS_REMAINING: X-Ratelimit-Remaining
   base_url: https://api.openrouteservice.org
-  key:
+  key: ''
   name: openrouteservice
+  timeout: 60

--- a/ORStools/gui/ORStoolsDialogConfig.py
+++ b/ORStools/gui/ORStoolsDialogConfig.py
@@ -31,7 +31,8 @@ from qgis.gui import QgsCollapsibleGroupBox
 
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QMetaObject
-from PyQt5.QtWidgets import QDialog, QInputDialog
+from PyQt5.QtWidgets import QDialog, QInputDialog, QLineEdit
+from PyQt5.QtGui import QIntValidator
 
 from ORStools.utils import configmanager
 from .ORStoolsDialogConfigUI import Ui_ORStoolsDialogConfigBase
@@ -66,9 +67,31 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
             current_provider = self.temp_config['providers'][idx]
             current_provider['key'] = box.findChild(QtWidgets.QLineEdit, box.title() + "_key_text").text()
             current_provider['base_url'] = box.findChild(QtWidgets.QLineEdit, box.title() + "_base_url_text").text()
+            timeout_input = box.findChild(QtWidgets.QLineEdit, box.title() + "_timeout_text")
+            # https://doc.qt.io/qt-5/qvalidator.html#State-enum
+            if timeout_input.validator().State() != 2:
+                self._adjust_timeout_input(timeout_input)
+            current_provider['timeout'] = int(timeout_input.text())
 
         configmanager.write_config(self.temp_config)
         self.close()
+
+    @staticmethod
+    def _adjust_timeout_input(input_line_edit: QLineEdit):
+        """
+        Corrects the value of the input to the top or bottom value of
+        the specified range of the QIntValidator for the field.
+        Default to a timeout of 60 seconds if no value is given.
+        :param input_line_edit: QLineEdit object to adjust
+        """
+        val = input_line_edit.validator()
+        text = input_line_edit.text()
+        if not text:
+            input_line_edit.setText('60')
+        elif int(text) < val.bottom():
+            input_line_edit.setText(str(val.bottom()))
+        elif int(text) > val.top():
+            input_line_edit.setText(str(val.top()))
 
     def _build_ui(self):
         """Builds the UI on dialog startup."""
@@ -77,6 +100,7 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
             self._add_box(provider_entry['name'],
                           provider_entry['base_url'],
                           provider_entry['key'],
+                          provider_entry['timeout'],
                           new=False)
 
         self.gridLayout.addWidget(self.providers, 0, 0, 1, 3)
@@ -93,7 +117,7 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
         # Show quick user input dialog
         provider_name, ok = QInputDialog.getText(self, "New ORS provider", "Enter a name for the provider")
         if ok:
-            self._add_box(provider_name, 'https://', '', new=True)
+            self._add_box(provider_name, 'https://', '', 60, new=True)
 
     def _remove_provider(self):
         """Remove list of providers from list."""
@@ -123,6 +147,7 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
                  name,
                  url,
                  key,
+                 timeout,
                  new=False):
         """
         Adds a provider box to the QWidget layout and self.temp_config.
@@ -145,6 +170,7 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
                     name=name,
                     base_url=url,
                     key=key,
+                    timeout=timeout
                 )
             )
 
@@ -157,10 +183,6 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
         key_label.setObjectName(name + '_key_label')
         key_label.setText('API Key')
         gridLayout_3.addWidget(key_label, 0, 0, 1, 1)
-        base_url_text = QtWidgets.QLineEdit(provider)
-        base_url_text.setObjectName(name + "_base_url_text")
-        base_url_text.setText(url)
-        gridLayout_3.addWidget(base_url_text, 3, 0, 1, 4)
         key_text = QtWidgets.QLineEdit(provider)
         key_text.setObjectName(name + "_key_text")
         key_text.setText(key)
@@ -169,5 +191,20 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
         base_url_label.setObjectName("base_url_label")
         base_url_label.setText("Base URL")
         gridLayout_3.addWidget(base_url_label, 2, 0, 1, 1)
+        base_url_text = QtWidgets.QLineEdit(provider)
+        base_url_text.setObjectName(name + "_base_url_text")
+        base_url_text.setText(url)
+        gridLayout_3.addWidget(base_url_text, 3, 0, 1, 4)
+
+        timeout_label = QtWidgets.QLabel(provider)
+        timeout_label.setObjectName("timeout_label")
+        timeout_label.setText("Request timeout in seconds (1 - 3600)")
+        gridLayout_3.addWidget(timeout_label, 4, 0, 1, 1)
+        timeout_text = QtWidgets.QLineEdit(provider)
+        timeout_text.setObjectName(name + "_timeout_text")
+        timeout_text.setText(str(timeout))
+        timeout_text.setValidator(QIntValidator(1, 3600, timeout_text))
+        gridLayout_3.addWidget(timeout_text, 5, 0, 1, 4)
+
         self.verticalLayout.addWidget(provider)
         provider.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)


### PR DESCRIPTION
This is based on #121 by @jannefleischer.

It addresses the requested changes from said PR.
Most notably, it drops a bunch of `int()`-conversions, since it adds a `QIntValidator` for the timeout-field.
Timeout will default to 60s if not set.

Fixes #122 