### PR TITLE
Add exception for network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ RELEASING:
 - implement `options`-parameter for routing and isochrones
 - prepare `options`-parameter for matrix
 - custom request timeouts for providers ([#122](https://github.com/GIScience/orstools-qgis-plugin/issues/122))
+- exception on network failures due to unresponsive provider
 
 ## [1.4.0] - 2021-06-15
 

--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -204,25 +204,28 @@ class Client(QObject):
         status_code = self.nam.http_call_result.status_code
         message = self.nam.http_call_result.text if self.nam.http_call_result.text != '' else self.nam.http_call_result.reason
 
-        if status_code == 403:
+        if not status_code:
+            raise Exception(f"{message}. Are your provider settings correct and the provider ready?")
+
+        elif status_code == 403:
             raise exceptions.InvalidKey(
                 str(status_code),
                 message
             )
 
-        if status_code == 429:
+        elif status_code == 429:
             raise exceptions.OverQueryLimit(
                 str(status_code),
                 message
             )
         # Internal error message for Bad Request
-        if 400 <= status_code < 500:
+        elif 400 <= status_code < 500:
             raise exceptions.ApiError(
                 str(status_code),
                 message
             )
         # Other HTTP errors have different formatting
-        if status_code != 200:
+        elif status_code != 200:
             raise exceptions.GenericServerError(
                 str(status_code),
                 message


### PR DESCRIPTION
if an invalid provider url was set, where the provider is
unresponsive, only a generaly python error without info was returend.

An exception was added in this case indicating the network error
and suggesting to adjust the provider config.