### PR TITLE
Fix: comment out option parsing for matrix algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ RELEASING:
  -->
 ## Unreleased
 
+### Fixed
+- matrix algorithm parsing hidden options ([#164](https://github.com/GIScience/orstools-qgis-plugin/issues/164))
+
 ## [1.5.0] - 2021-12-08
 
 ### Added

--- a/ORStools/proc/base_processing_algorithm.py
+++ b/ORStools/proc/base_processing_algorithm.py
@@ -188,7 +188,6 @@ class ORSBaseProcessingAlgorithm(QgsProcessingAlgorithm):
         ors_client.overQueryLimit.connect(lambda: feedback.reportError("OverQueryLimit: Retrying..."))
         return ors_client
 
-
     def parseOptions(self, parameters: dict, context: QgsProcessingContext) -> dict:
         options = dict()
 

--- a/ORStools/proc/matrix_proc.py
+++ b/ORStools/proc/matrix_proc.py
@@ -88,7 +88,8 @@ class ORSMatrixAlgo(ORSBaseProcessingAlgorithm):
         # Get profile value
         profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
 
-        options = self.parseOptions(parameters, context)
+        # TODO: enable once core matrix is available
+        # options = self.parseOptions(parameters, context)
 
         # Get parameter values
         source = self.parameterAsSource(
@@ -146,8 +147,8 @@ class ORSMatrixAlgo(ORSBaseProcessingAlgorithm):
             'sources': sources_ids,
             'destinations': destination_ids,
             'metrics': ["duration", "distance"],
-            'id': 'Matrix',
-            'options': options
+            'id': 'Matrix'
+            # 'options': options
         }
 
         # get types of set ID fields


### PR DESCRIPTION
parseOptions of the ORSBaseProcessingAlgorithm was looking for
option parameters that are still hidden for matrix.

parseOptions is now not called in the matrix algorithm and needs to be
called once the options are integrated for matrix in the ors backend.

Fixes https://github.com/GIScience/orstools-qgis-plugin/issues/164