### PR TITLE
Move config-yaml to general plugin folder to keep it from being overridden upon plugin update. 

### DIFF
--- a/ORStools/__init__.py
+++ b/ORStools/__init__.py
@@ -30,6 +30,7 @@
 import os.path
 import configparser
 from datetime import datetime
+import shutil
 
 
 # noinspection PyPep8Naming
@@ -49,8 +50,13 @@ PLUGIN_NAME = 'ORS Tools'
 DEFAULT_COLOR = '#a8b1f5'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# Create config-yaml outside plugin folder to keep settings upon plugin update
+CONFIG_PATH = os.path.join(os.path.dirname(BASE_DIR), 'ORStools_config.yml')
+if not os.path.isfile(CONFIG_PATH):
+    src = os.path.join(BASE_DIR, "config.yml")
+    shutil.copyfile(src, CONFIG_PATH)
+
 RESOURCE_PREFIX = ":plugins/ORStools/img/"
-CONFIG_PATH = os.path.join(BASE_DIR, 'config.yml')
 ENV_VARS = {'ORS_REMAINING': 'X-Ratelimit-Remaining',
             'ORS_QUOTA': 'X-Ratelimit-Limit'}
 

--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -48,7 +48,7 @@ class Client(QObject):
 
     def __init__(self, provider=None):
         """
-        :param provider: A openrouteservice provider from config.yml
+        :param provider: A openrouteservice provider from ORStools_config.yml
         :type provider: dict
 
         :param retry_timeout: Timeout across multiple retryable requests, in

--- a/ORStools/gui/ORStoolsDialog.py
+++ b/ORStools/gui/ORStoolsDialog.py
@@ -412,7 +412,7 @@ class ORStoolsDialog(QDialog, Ui_ORStoolsDialogBase):
         self.batch_matrix.clicked.connect(lambda: processing.execAlgorithmDialog(f'{PLUGIN_NAME}:matrix_from_layers'))
 
     def _on_prov_refresh_click(self):
-        """Populates provider dropdown with fresh list from config.yml"""
+        """Populates provider dropdown with fresh list from ORStools_config.yml"""
 
         providers = configmanager.read_config()['providers']
         self.provider_combo.clear()

--- a/ORStools/gui/ORStoolsDialogConfig.py
+++ b/ORStools/gui/ORStoolsDialogConfig.py
@@ -60,7 +60,7 @@ class ORStoolsDialogConfigMain(QDialog, Ui_ORStoolsDialogConfigBase):
         self.provider_remove.clicked.connect(self._remove_provider)
 
     def accept(self):
-        """When the OK Button is clicked, in-memory temp_config is updated and written to config.yml"""
+        """When the OK Button is clicked, in-memory temp_config is updated and written to ORStools_config.yml"""
 
         collapsible_boxes = self.providers.findChildren(QgsCollapsibleGroupBox)
         for idx, box in enumerate(collapsible_boxes):

--- a/ORStools/utils/configmanager.py
+++ b/ORStools/utils/configmanager.py
@@ -35,7 +35,7 @@ from ORStools import CONFIG_PATH
 
 def read_config():
     """
-    Reads config.yml from file and returns the parsed dict.
+    Reads ORStools_config.yml from file and returns the parsed dict.
 
     :returns: Parsed settings dictionary.
     :rtype: dict


### PR DESCRIPTION
This way the config file is not deleted, when the plugin itself is deleted, maybe this should be implemented aswell?