### PR TITLE
fix: annotations stay after saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,19 +40,18 @@ RELEASING:
 14. Create new release in GitHub with tag version and release title of `vX.X.X`
  -->
 
-# Unreleased
-- Add option to export order of optimization route points ([#145](https://github.com/GIScience/orstools-qgis-plugin/issues/145))
-
 ## Unreleased
 
 ### Fixed
 - QGis crashes when selecting more than two vertices for deletion ([#230](https://github.com/GIScience/orstools-qgis-plugin/issues/230))
 - Vertices on canvas not depicted fully with n having more than one digit in length ([#235](https://github.com/GIScience/orstools-qgis-plugin/issues/235))
 - Replace qt QSettings with QgsSettings for centralized configuration management ([#239](https://github.com/GIScience/orstools-qgis-plugin/issues/239))
+- Fix: Point Annotations stay after saving project and not deleting them manually([#229](https://github.com/GIScience/orstools-qgis-plugin/issues/229))
 
 ### Added
 - Add support for decimal ranges with isochrones([#237](https://github.com/GIScience/orstools-qgis-plugin/issues/237))
 - Add hint for joining with `Layer ID Field` ([#143](https://github.com/GIScience/orstools-qgis-plugin/issues/143))
+- Add option to export order of optimization route points ([#145](https://github.com/GIScience/orstools-qgis-plugin/issues/145))
 
 ### Changed
 - Rename `Ok` button in configuration window to `Save` for clarification([#241](https://github.com/GIScience/orstools-qgis-plugin/issues/241))

--- a/ORStools/gui/ORStoolsDialog.py
+++ b/ORStools/gui/ORStoolsDialog.py
@@ -479,6 +479,8 @@ class ORStoolsDialog(QDialog, Ui_ORStoolsDialogBase):
         self.routing_fromline_list.model().rowsMoved.connect(self._reindex_list_items)
         self.routing_fromline_list.model().rowsRemoved.connect(self._reindex_list_items)
 
+        self.annotation_canvas = self._iface.mapCanvas()
+
     def _save_vertices_to_layer(self):
         """Saves the vertices list to a temp layer"""
         items = [
@@ -550,11 +552,12 @@ class ORStoolsDialog(QDialog, Ui_ORStoolsDialogBase):
         annotation.setMapPosition(point)
         annotation.setMapPositionCrs(crs)
 
-        return QgsMapCanvasAnnotationItem(annotation, self._iface.mapCanvas()).annotation()
+        return QgsMapCanvasAnnotationItem(annotation, self.annotation_canvas).annotation()
 
     def _clear_annotations(self):
         """Clears annotations"""
-        for annotation in self.annotations:
+        for annotation_item in self.annotation_canvas.annotationItems():
+            annotation = annotation_item.annotation()
             if annotation in self.project.annotationManager().annotations():
                 self.project.annotationManager().removeAnnotation(annotation)
         self.annotations = []
@@ -586,7 +589,6 @@ class ORStoolsDialog(QDialog, Ui_ORStoolsDialogBase):
         self.routing_fromline_list.addItem(f"Point {idx}: {point_wgs.x():.6f}, {point_wgs.y():.6f}")
 
         annotation = self._linetool_annotate_point(point, idx)
-        self.annotations.append(annotation)
         self.project.annotationManager().addAnnotation(annotation)
 
     def _reindex_list_items(self):
@@ -606,7 +608,6 @@ class ORStoolsDialog(QDialog, Ui_ORStoolsDialogBase):
 
             self.routing_fromline_list.addItem(item)
             annotation = self._linetool_annotate_point(point, idx, crs)
-            self.annotations.append(annotation)
             self.project.annotationManager().addAnnotation(annotation)
 
     def _on_linetool_map_doubleclick(self):

--- a/ORStools/proc/base_processing_algorithm.py
+++ b/ORStools/proc/base_processing_algorithm.py
@@ -27,7 +27,7 @@
  ***************************************************************************/
 """
 
-from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtCore import QCoreApplication, QSettings
 from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,

--- a/ORStools/proc/base_processing_algorithm.py
+++ b/ORStools/proc/base_processing_algorithm.py
@@ -27,7 +27,7 @@
  ***************************************************************************/
 """
 
-from PyQt5.QtCore import QCoreApplication, QSettings
+from PyQt5.QtCore import QCoreApplication
 from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,


### PR DESCRIPTION
Annotations are now stored within a `canvas` instance. They can be deleted using the red x button even after saving and reopening a project. 