### PR TITLE
fix: extend color dict for isochrones by one to improve error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ RELEASING:
 14. Create new release in GitHub with tag version and release title of `vX.X.X`
  -->
 
+## Unreleased
+### Fixed
+- Log the correct ApiError message in the isochrone processing algorithm with > 10 ranges ([#264](https://github.com/GIScience/orstools-qgis-plugin/issues/264))
+
 ## [1.8.3] - 2024-05-29
 
 ### Fixed

--- a/ORStools/common/isochrones_core.py
+++ b/ORStools/common/isochrones_core.py
@@ -195,6 +195,7 @@ class Isochrones:
             7: QColor("#f99e59"),
             8: QColor("#e85b3a"),
             9: QColor("#d7191c"),
+            10: None,
         }
 
         categories = []


### PR DESCRIPTION
To log the correct ApiError message in the isochrone processing algorithm window, when there are more than 10 ranges inputted. 

Otherwise this will be printed: 
```Traceback (most recent call last):
File "/home/adroit/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ORStools/proc/isochrones_layer_proc.py", line 218, in postProcessAlgorithm
self.isochrones.stylePoly(processed_layer)
File "/home/adroit/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ORStools/common/isochrones_core.py", line 208, in stylePoly
color=colors[cid], strokeColor=QColor("#000000")
KeyError: 10```