### PR TITLE
fix: check for duplicates in proc with traveling salesman 

### DIFF
--- a/ORStools/proc/directions_points_layer_proc.py
+++ b/ORStools/proc/directions_points_layer_proc.py
@@ -218,6 +218,12 @@ class ORSDirectionsPointsLayerAlgo(ORSBaseProcessingAlgorithm):
 
             try:
                 if optimization_mode is not None:
+                    # check for duplicate points
+                    if len(points) != len(set(points)):
+                        raise exceptions.DuplicateError(
+                            "There are duplicate points in the input layer, which need to be removed."
+                        )
+
                     params = get_params_optimize(points, profile, optimization_mode)
                     response = ors_client.request("/optimization", {}, post_json=params)
 

--- a/ORStools/utils/exceptions.py
+++ b/ORStools/utils/exceptions.py
@@ -92,3 +92,11 @@ class GenericServerError(Exception):
             return self.status
         else:
             return f"{self.status} ({self.message})"
+
+
+class DuplicateError(Exception):
+    def __init__(self, message=None):
+        self.message = message
+
+    def __str__(self):
+        return self.message


### PR DESCRIPTION
This checks whether the input list `points` has any duplicates and if so raises a new `DuplicateError`.