### PR TITLE
fix: less than two vertices not accepted wit optimization and live preview

### DIFF
--- a/ORStools/utils/maptools.py
+++ b/ORStools/utils/maptools.py
@@ -269,6 +269,8 @@ class LineTool(QgsMapToolEmitPoint):
         self.last_click = "double-click"
 
     def create_rubber_band(self) -> None:
+        if self.dlg.optimization_group.isChecked() and self.dlg.routing_fromline_list.count() == 2:
+            return
         if self.dlg.rubber_band:
             self.dlg.rubber_band.reset()
         else:

--- a/ORStools/utils/router.py
+++ b/ORStools/utils/router.py
@@ -120,5 +120,5 @@ Please add polygons to the layer or uncheck avoid polygons.
         dlg.debug_text.setHtml(clnt_msg)
 
 
-def tr(self, string: str) -> str:
-    return QCoreApplication.translate(str(self.__class__.__name__), string)
+def tr(string: str) -> str:
+    return QCoreApplication.translate("ORStoolsDialogMain", string)


### PR DESCRIPTION
Rubber band will here not be generated if n points == 2 and optimization option is checked.