### PR TITLE
fix: error with route calculation without vertices

### DIFF
--- a/ORStools/gui/ORStoolsDialog.py
+++ b/ORStools/gui/ORStoolsDialog.py
@@ -246,6 +246,8 @@ class ORStoolsDialogMain:
 
     def run_gui_control(self) -> None:
         """Slot function for OK button of main dialog."""
+        if self.dlg.routing_fromline_list.count() == 0:
+            return
         basepath = os.path.dirname(__file__)
 
         # add ors svg path


### PR DESCRIPTION
An error was raised when main plugin was executed and the list was empty. In this case, the execution is now ignored. 