### PR TITLE
Made ORSTools ready for qgis_process

### DIFF
--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -50,7 +50,8 @@ class ORStools:
         :type iface: QgsInterface
         """
         self.dialog = ORStoolsDialog.ORStoolsDialogMain(iface)
-        self.provider = provider.ORStoolsProvider()
+        # should be done in initProcessing, so that qgis_process can skip GUI.
+        # self.provider = provider.ORStoolsProvider()
 
         # initialize plugin directory
         self.plugin_dir = os.path.dirname(__file__)
@@ -75,10 +76,16 @@ class ORStools:
 
         self.add_default_provider_to_settings()
 
+    def initProcessing(self):
+        self.provider = provider.ORStoolsProvider()
+        QgsApplication.processingRegistry().addProvider(self.provider)
+
     def initGui(self) -> None:
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
 
-        QgsApplication.processingRegistry().addProvider(self.provider)
+        #QgsApplication.processingRegistry().addProvider(self.provider)
+        self.initProcessing()
+        
         self.dialog.initGui()
 
     def unload(self) -> None:

--- a/ORStools/proc/add_provider_conf.py
+++ b/ORStools/proc/add_provider_conf.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ ORStools
+                                 A QGIS plugin
+ QGIS client to query openrouteservice
+                              -------------------
+        begin                : 2017-02-01
+        git sha              : $Format:%H$
+        copyright            : (C) 2021 by HeiGIT gGmbH
+        email                : support@openrouteservice.heigit.org
+ ***************************************************************************/
+
+ This plugin provides access to openrouteservice API functionalities
+ (https://openrouteservice.org), developed and
+ maintained by the openrouteservice team of HeiGIT gGmbH, Germany. By using
+ this plugin you agree to the ORS terms of service
+ (https://openrouteservice.org/terms-of-service/).
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from typing import Dict
+
+from qgis.PyQt.QtCore import QCoreApplication
+
+from qgis.core import (
+    QgsSettings,
+    QgsProcessingAlgorithm,
+    QgsProcessingParameterString,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterBoolean,
+    QgsProcessingContext,
+    QgsProcessingFeedback,
+)
+
+from ORStools.utils import logger
+from ..proc import ENDPOINTS
+
+class ORSProviderAddAlgo(QgsProcessingAlgorithm):
+    def __init__(self):
+        super().__init__()
+        self.PARAMETERS: list = [
+            QgsProcessingParameterString(
+                name="ors_provider_name",
+                description=self.tr(
+                    "Set unique name for your ors provider"
+                ),
+            ),
+            QgsProcessingParameterString(
+                name="ors_provider_api_key",
+                description=self.tr(
+                    "Set api key for your ors provider"
+                ),
+                optional=True
+            ),
+            QgsProcessingParameterString(
+                name="ors_provider_url",
+                description=self.tr(
+                    "Set url to ors api"
+                ),
+            ),
+            QgsProcessingParameterNumber(
+                name="ors_provider_timeout",
+                description=self.tr(
+                    "Set custom timeout (in seconds)"
+                ),
+                defaultValue=60
+            ),
+            QgsProcessingParameterBoolean(
+                name="ors_provider_overwrite",
+                description=self.tr(
+                    "If True, existing provider is overwritten"
+                ),
+                defaultValue=False
+            ),
+            #TODO: Service Endpoints
+            # QgsProcessingParameterString(
+            #     name="otp_endpoint_directions",
+            #     description=self.tr("Endpoint for directions on your provider"),
+            #     defaultValue="directions",
+            #     optional=True
+            # ),
+        ]
+
+    def group(self):
+        return "Configuration"
+
+    def groupId(self):
+        return "configuration"
+
+    def initAlgorithm(self, config={}):
+        for parameter in self.PARAMETERS:
+            self.addParameter(parameter)
+            
+    def processAlgorithm(
+        self, parameters: dict, context: QgsProcessingContext, feedback: QgsProcessingFeedback
+    ) -> Dict[str, str]:
+        s = QgsSettings()
+        provider_name = self.parameterAsString(
+            parameters,
+            "ors_provider_name",
+            context
+        )
+        provider_url = self.parameterAsString(
+            parameters,
+            "ors_provider_url",
+            context
+        )
+        provider_api_key = self.parameterAsString(
+            parameters,
+            "ors_provider_api_key",
+            context
+        )
+        provider_timeout = self.parameterAsInt(
+            parameters,
+            "ors_provider_timeout",
+            context
+        )
+        provider_overwrite = self.parameterAsBoolean(
+            parameters,
+            "ors_provider_timeout",
+            context
+        )
+
+        current_config = s.value("ORStools/config")
+        feedback.pushInfo(str(ENDPOINTS))
+        logger.log(str(ENDPOINTS), 2)
+        if (provider_name in [x['name'] for x in current_config['providers']]):
+            if (provider_overwrite):
+                msg = f"A provider with the name '{provider_name}' already exists. Replacement not yet implemented."
+            else:
+                #ignoring reset of settings for now.
+                msg = f"A provider with the name '{provider_name}' already exists. Please mark overwrite checkbox."
+            feedback.pushInfo(msg)
+            logger.log(msg, 2)
+            return {
+                "OUTPUT": msg
+            }
+        else:
+            existing_config = s.value("ORStools/config")
+            s.setValue(
+                "ORStools/config", 
+                {
+                    'providers': existing_config['providers'] + [
+                        { 
+                            'base_url': provider_url, 
+                            'key': provider_api_key, 
+                            'name': provider_name, 
+                            'timeout': provider_timeout,
+                            'endpoints': ENDPOINTS #TODO: customize"new config added: "
+                        }
+                    ]
+                }
+            )
+
+            return {
+                "OUTPUT": f"new config added: {provider_name}"
+            }
+
+    def createInstance(self):
+        return self.__class__()
+
+    def name(self):
+        return "set_provider_config_to_ors_via_algorithm"
+
+    def displayName(self) -> str:
+        """
+        Algorithm name shown in QGIS toolbox
+        :return:
+        """
+        return self.tr("Set Provider Config via Algorithm (e.g. headless)")
+    
+    def tr(self, string: str, context=None) -> str:
+        context = context or self.__class__.__name__
+        return QCoreApplication.translate(context, string)
+        #return string #disabling QCoreApplication.translate due to Qt

--- a/ORStools/proc/base_processing_algorithm.py
+++ b/ORStools/proc/base_processing_algorithm.py
@@ -179,9 +179,9 @@ class ORSBaseProcessingAlgorithm(QgsProcessingAlgorithm):
             ),
         ]
 
-    def get_endpoint_names_from_provider(self, provider: str) -> dict:
+    def get_endpoint_names_from_provider(self, provider: str | int ) -> dict:
         providers = configmanager.read_config()["providers"]
-        ors_provider = providers[provider]
+        ors_provider = providers[int(provider)]
         return ors_provider["endpoints"]
 
     @classmethod

--- a/ORStools/proc/base_processing_algorithm.py
+++ b/ORStools/proc/base_processing_algorithm.py
@@ -186,7 +186,7 @@ class ORSBaseProcessingAlgorithm(QgsProcessingAlgorithm):
 
     @classmethod
     def _get_ors_client_from_provider(
-        cls, provider: str, feedback: QgsProcessingFeedback
+        cls, provider: str | int, feedback: QgsProcessingFeedback
     ) -> client.Client:
         """
         Connects client to provider and returns a client instance for requests to the ors API
@@ -196,7 +196,7 @@ class ORSBaseProcessingAlgorithm(QgsProcessingAlgorithm):
         agent = f"QGIS_{name}"
 
         providers = configmanager.read_config()["providers"]
-        ors_provider = providers[provider]
+        ors_provider = providers[int(provider)]
         ors_client = client.Client(ors_provider, agent)
         ors_client.overQueryLimit.connect(
             lambda: feedback.reportError("OverQueryLimit: Retrying...")

--- a/ORStools/proc/directions_lines_proc.py
+++ b/ORStools/proc/directions_lines_proc.py
@@ -129,7 +129,7 @@ class ORSDirectionsLinesAlgo(ORSBaseProcessingAlgorithm):
     ) -> Dict[str, str]:
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         preference = dict(enumerate(PREFERENCES))[parameters[self.IN_PREFERENCE]]
 

--- a/ORStools/proc/directions_points_layer_proc.py
+++ b/ORStools/proc/directions_points_layer_proc.py
@@ -137,7 +137,7 @@ class ORSDirectionsPointsLayerAlgo(ORSBaseProcessingAlgorithm):
     ) -> Dict[str, str]:
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         preference = dict(enumerate(PREFERENCES))[parameters[self.IN_PREFERENCE]]
 

--- a/ORStools/proc/directions_points_layers_proc.py
+++ b/ORStools/proc/directions_points_layers_proc.py
@@ -148,7 +148,7 @@ class ORSDirectionsPointsLayersAlgo(ORSBaseProcessingAlgorithm):
     ) -> Dict[str, str]:
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         preference = dict(enumerate(PREFERENCES))[parameters[self.IN_PREFERENCE]]
 

--- a/ORStools/proc/export_proc.py
+++ b/ORStools/proc/export_proc.py
@@ -76,7 +76,7 @@ class ORSExportAlgo(ORSBaseProcessingAlgorithm):
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
         # Get profile value
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         target_crs = QgsCoordinateReferenceSystem("EPSG:4326")
         rect = self.parameterAsExtent(parameters, self.IN_EXPORT, context, crs=target_crs)

--- a/ORStools/proc/isochrones_layer_proc.py
+++ b/ORStools/proc/isochrones_layer_proc.py
@@ -121,10 +121,10 @@ class ORSIsochronesLayerAlgo(ORSBaseProcessingAlgorithm):
         self, parameters: dict, context: QgsProcessingContext, feedback: QgsProcessingFeedback
     ) -> Dict[str, str]:
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
-
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
-        dimension = dict(enumerate(DIMENSIONS))[parameters[self.IN_METRIC]]
-        location_type = dict(enumerate(LOCATION_TYPES))[parameters[self.LOCATION_TYPE]]
+        
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
+        dimension = dict(enumerate(DIMENSIONS))[int(parameters[self.IN_METRIC])]
+        location_type = dict(enumerate(LOCATION_TYPES))[int(parameters[self.LOCATION_TYPE])]
 
         factor = 60 if dimension == "time" else 1
         ranges_raw = parameters[self.IN_RANGES]

--- a/ORStools/proc/isochrones_point_proc.py
+++ b/ORStools/proc/isochrones_point_proc.py
@@ -107,10 +107,9 @@ class ORSIsochronesPointAlgo(ORSBaseProcessingAlgorithm):
         self, parameters: dict, context: QgsProcessingContext, feedback: QgsProcessingFeedback
     ) -> Dict[str, str]:
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
-
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
-        dimension = dict(enumerate(DIMENSIONS))[parameters[self.IN_METRIC]]
-        location_type = dict(enumerate(LOCATION_TYPES))[parameters[self.LOCATION_TYPE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
+        dimension = dict(enumerate(DIMENSIONS))[int(parameters[self.IN_METRIC])]
+        location_type = dict(enumerate(LOCATION_TYPES))[int(parameters[self.LOCATION_TYPE])]
 
         factor = 60 if dimension == "time" else 1
         ranges_raw = parameters[self.IN_RANGES]

--- a/ORStools/proc/matrix_proc.py
+++ b/ORStools/proc/matrix_proc.py
@@ -93,7 +93,7 @@ class ORSMatrixAlgo(ORSBaseProcessingAlgorithm):
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
         # Get profile value
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         # TODO: enable once core matrix is available
         # options = self.parseOptions(parameters, context)

--- a/ORStools/proc/provider.py
+++ b/ORStools/proc/provider.py
@@ -38,6 +38,7 @@ from .export_proc import ORSExportAlgo
 from .isochrones_layer_proc import ORSIsochronesLayerAlgo
 from .isochrones_point_proc import ORSIsochronesPointAlgo
 from .matrix_proc import ORSMatrixAlgo
+from .add_provider_conf import ORSProviderAddAlgo
 from ORStools.utils.gui import GuiUtils
 
 from .snap_layer_proc import ORSSnapLayerAlgo
@@ -70,6 +71,7 @@ class ORStoolsProvider(QgsProcessingProvider):
         self.addAlgorithm(ORSExportAlgo())
         self.addAlgorithm(ORSSnapLayerAlgo())
         self.addAlgorithm(ORSSnapPointAlgo())
+        self.addAlgorithm(ORSProviderAddAlgo())
 
     @staticmethod
     def icon():

--- a/ORStools/proc/snap_layer_proc.py
+++ b/ORStools/proc/snap_layer_proc.py
@@ -76,7 +76,7 @@ class ORSSnapLayerAlgo(ORSBaseProcessingAlgorithm):
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
         # Get profile value
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         # Get parameter values
         source = self.parameterAsSource(parameters, self.IN_POINTS, context)

--- a/ORStools/proc/snap_point_proc.py
+++ b/ORStools/proc/snap_point_proc.py
@@ -79,7 +79,7 @@ class ORSSnapPointAlgo(ORSBaseProcessingAlgorithm):
         ors_client = self._get_ors_client_from_provider(parameters[self.IN_PROVIDER], feedback)
 
         # Get profile value
-        profile = dict(enumerate(PROFILES))[parameters[self.IN_PROFILE]]
+        profile = dict(enumerate(PROFILES))[int(parameters[self.IN_PROFILE])]
 
         # Get parameter values
         point = self.parameterAsPoint(parameters, self.IN_POINT, context, self.crs_out)

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -7,6 +7,7 @@ from qgis.core import (
     QgsFeature,
     QgsGeometry,
     QgsRectangle,
+    QgsSettings,
 )
 from qgis.testing import unittest
 from qgis.PyQt.QtCore import QMetaType
@@ -20,6 +21,7 @@ from ORStools.proc.isochrones_point_proc import ORSIsochronesPointAlgo
 from ORStools.proc.matrix_proc import ORSMatrixAlgo
 from ORStools.proc.snap_layer_proc import ORSSnapLayerAlgo
 from ORStools.proc.snap_point_proc import ORSSnapPointAlgo
+from ORStools.proc.add_provider_conf import ORSProviderAddAlgo
 
 
 class TestProc(unittest.TestCase):
@@ -277,3 +279,32 @@ class TestProc(unittest.TestCase):
         self.assertRaises(
             Exception, lambda: snap_points.processAlgorithm(parameters, self.context, self.feedback)
         )
+
+    def test_add_provider(self):
+        parameters = {
+            "ors_provider_name": "TestProvider",
+            "ors_provider_api_key": "test_api_key",
+            "ors_provider_url": "https://test.example.org",
+            "ors_provider_timeout": 120,
+            "ors_provider_overwrite": False,
+        }
+
+        # Create an instance of the algorithm
+        add_provider_algo = ORSProviderAddAlgo().create()
+
+        # Run the algorithm
+        result = add_provider_algo.processAlgorithm(parameters, self.context, self.feedback)
+
+        # Validate the result
+        self.assertIn("OUTPUT", result)
+        self.assertEqual(result["OUTPUT"], "new config added: TestProvider")
+
+        # Verify the provider was added to the settings
+        settings = QgsSettings()
+        config = settings.value("ORStools/config")
+        providers = config["providers"]
+        self.assertTrue(any(provider["name"] == "TestProvider" for provider in providers))
+
+        # Clean up by removing the test provider
+        config["providers"] = [provider for provider in providers if provider["name"] != "TestProvider"]
+        settings.setValue("ORStools/config", config)


### PR DESCRIPTION
Because I need to run our plugin OS-WALK-EU (which depends on isocrone calculations from ORStools) from within a qgis_process setup headless I needed some upstream changes:

1. moved the initiation of the processing toolbox to initProcessing, so qgis_process can skip everything with a GUI involved
2. Added some recasting of parameters to int, because qgis_process interprets numbers as strings...
3. Added an configuration-processing-algorithm (so my headless machine can have a custom provider). Added a test to that, but never done tests before (just a urban planner doing some programming...)

Now I can run something like this from the command line:

```bash
qgis_process plugins enable "ORStools" && qgis_process run "ORS Tools:set_provider_config_to_ors_via_algorithm" -- distance_units=meters area_units=m2 ellipsoid=EPSG:7019 ors_provider_name=ors.onmyserver.de ors_provider_api_key= ors_provider_url=https://ors.onmyserver.de ors_provider_timeout=240 ors_provider_overwrite=true
```

followed by:

```bash
echo '{                                                                                                            
        "distance_units": "meters", 
        "area_units": "m2",
        "ellipsoid": "EPSG:7019",
        "inputs": {
                "INPUT_PROVIDER": 1,
                "INPUT_PROFILE": 0,
                "INPUT_POINT_LAYER": "/home/fleischer/srv-fs1/u/02_Code_Working_Trees/os-walk-eu/SampleData/SampleGrid_centroids.shp",
                "INPUT_FIELD": "GRD_ID",
                "INPUT_METRIC": 1,
                "INPUT_RANGES": "250,500,750,1000",
                "LOCATION_TYPE": 0,
                "INPUT_SMOOTHING": 0,
                "INPUT_AVOID_FEATURES": [],
                "INPUT_AVOID_COUNTRIES": null,
                "INPUT_AVOID_BORDERS": null,
                "OUTPUT": "/home/fleischer/srv-fs1/u/02_Code_Working_Trees/os-walk-eu/SampleData/SampleGrid_centroid_isochrones_orstools.shp"
    }
}' | qgis_process run "ORS Tools:isochrones_from_layer" -

Due to `None`/`null`-Values and `[]` as parameters, only the json-piping is working.

```