### PR TITLE
fix: QVariant.Type not available in Qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ RELEASING:
 ### Fixed
 - Delete annotations when plugin is uninstalled ([#346](https://github.com/GIScience/orstools-qgis-plugin/issues/346))
 - Reset hand cursor after deactivating line tool ([#342](https://github.com/GIScience/orstools-qgis-plugin/issues/342))
+- Qt6 incompatibility with QVariant ([#355](https://github.com/GIScience/orstools-qgis-plugin/issues/355))
 
 ## [2.0.1] - 2025-06-01
 ### Added

--- a/ORStools/utils/wrapper.py
+++ b/ORStools/utils/wrapper.py
@@ -28,7 +28,8 @@
  ***************************************************************************/
 """
 
-from typing import Union, Optional
+
+from typing import Union, Optional, Any
 
 from qgis.PyQt.QtCore import QMetaType, QVariant
 from qgis.core import QgsField, Qgis
@@ -36,20 +37,31 @@ from qgis.core import QgsField, Qgis
 
 def create_field_qgis_3_38_plus(
     name: str,
-    type_enum: Union[QMetaType.Type, QVariant.Type],
+    type_enum: Any,
     length: int,
     precision: int,
     comment: str,
-    subtype_enum: Optional[Union[QMetaType.Type, QVariant.Type]] = None,
+    subtype_enum: Optional[Any] = None,
 ) -> QgsField:
-    """Create a QgsField for QGIS ≥ 3.38 using QMetaType.Type enums."""
-    if isinstance(type_enum, QVariant.Type):
-        type_enum = QMetaType.Type(type_enum)
-    if subtype_enum and isinstance(subtype_enum, QVariant.Type):
-        subtype_enum = QMetaType.Type(subtype_enum)
+    """Create a QgsField for QGIS ≥ 3.38 using QMetaType.Type enums. Compatible with Qt6."""
+    # Qt6: QVariant.Type is an enum, QMetaType.Type is int
+    # Normalize to QVariant.Type
+    if hasattr(QVariant, "Type"):  # Qt5/Qt6 compatibility
+        if isinstance(type_enum, QMetaType.Type):
+            type_enum = QVariant.Type(type_enum)
+        elif isinstance(type_enum, int):
+            type_enum = QVariant.Type(type_enum)
+        if subtype_enum is not None:
+            if isinstance(subtype_enum, QMetaType.Type):
+                subtype_enum = QVariant.Type(subtype_enum)
+            elif isinstance(subtype_enum, int):
+                subtype_enum = QVariant.Type(subtype_enum)
+    else:
+        # Fallback for older Qt
+        pass
 
-    type_enum = QVariant.Type(type_enum)
-    subtype_enum = QVariant.Type(subtype_enum) if subtype_enum is not None else QVariant.Invalid
+    type_enum = type_enum if type_enum is not None else QVariant.Invalid
+    subtype_enum = subtype_enum if subtype_enum is not None else QVariant.Invalid
 
     return QgsField(
         name,

--- a/ORStools/utils/wrapper.py
+++ b/ORStools/utils/wrapper.py
@@ -28,7 +28,6 @@
  ***************************************************************************/
 """
 
-
 from typing import Union, Optional, Any
 
 from qgis.PyQt.QtCore import QMetaType, QVariant


### PR DESCRIPTION
Added check for the presents of an attribute `Type` in QVariant, which is absent in Qt6. And replaced type hint. 

Closes #355.