### PR TITLE
docs: changed read_config docstring, made use off it & introduction of deprecated URL dialog

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:system"
-}

--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -31,7 +31,6 @@ from qgis.gui import QgisInterface
 from qgis.utils import iface
 from qgis.core import QgsApplication, QgsSettings
 from qgis.PyQt.QtCore import QTranslator, qVersion, QCoreApplication, QLocale, QTimer
-from qgis.PyQt.QtWidgets import QMainWindow
 import os.path
 
 from .gui import ORStoolsDialog

--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -34,7 +34,7 @@ import os.path
 
 from .gui import ORStoolsDialog
 from .proc import provider, ENDPOINTS, DEFAULT_SETTINGS
-
+from .utils import read_config
 
 class ORStools:
     """QGIS Plugin Implementation."""
@@ -88,7 +88,7 @@ class ORStools:
 
     def add_default_provider_to_settings(self):
         s = QgsSettings()
-        settings = s.value("ORStools/config")
+        settings = read_config()
 
         settings_keys = ["ENV_VARS", "base_url", "key", "name", "endpoints"]
 

--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -30,7 +30,8 @@
 from qgis.gui import QgisInterface
 from qgis.utils import iface
 from qgis.core import QgsApplication, QgsSettings
-from qgis.PyQt.QtCore import QTranslator, qVersion, QCoreApplication, QLocale
+from qgis.PyQt.QtCore import QTranslator, qVersion, QCoreApplication, QLocale, QTimer
+from qgis.PyQt.QtWidgets import QMainWindow
 import os.path
 
 from .gui import ORStoolsDialog
@@ -84,7 +85,17 @@ class ORStools:
         QgsApplication.processingRegistry().addProvider(self.provider)
         self.dialog.initGui()
         # secures that the start of deprecated url dialog happens after QGIS Main-Window opened
-        iface.initializationCompleted.connect(self.check_provider_url)
+        self._wait_for_main_window()
+
+    def _wait_for_main_window(self) -> None:
+        """Wait until the QGIS main window is visible."""
+
+        main_window = iface.mainWindow()
+
+        if main_window is not None and main_window.isVisible():
+            self.check_provider_url()
+        else:
+            QTimer.singleShot(100, self._wait_for_main_window)
 
     def unload(self) -> None:
         """remove menu entry and toolbar icons"""

--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -28,13 +28,15 @@
 """
 
 from qgis.gui import QgisInterface
+from qgis.utils import iface
 from qgis.core import QgsApplication, QgsSettings
 from qgis.PyQt.QtCore import QTranslator, qVersion, QCoreApplication, QLocale
 import os.path
 
 from .gui import ORStoolsDialog
 from .proc import provider, ENDPOINTS, DEFAULT_SETTINGS
-from .utils import read_config
+from .utils import configmanager
+
 
 class ORStools:
     """QGIS Plugin Implementation."""
@@ -49,6 +51,7 @@ class ORStools:
             application at run time.
         :type iface: QgsInterface
         """
+        self.iface = iface
         self.dialog = ORStoolsDialog.ORStoolsDialogMain(iface)
         self.provider = provider.ORStoolsProvider()
 
@@ -80,6 +83,8 @@ class ORStools:
 
         QgsApplication.processingRegistry().addProvider(self.provider)
         self.dialog.initGui()
+        # starts deprecated url dialog after QGIS Main-Window opened
+        iface.initializationCompleted.connect(self.check_provider_url)
 
     def unload(self) -> None:
         """remove menu entry and toolbar icons"""
@@ -88,7 +93,7 @@ class ORStools:
 
     def add_default_provider_to_settings(self):
         s = QgsSettings()
-        settings = read_config()
+        settings = configmanager.read_config()
 
         settings_keys = ["ENV_VARS", "base_url", "key", "name", "endpoints"]
 
@@ -105,3 +110,28 @@ class ORStools:
                 s.setValue("ORStools/config", settings)
         else:
             s.setValue("ORStools/config", DEFAULT_SETTINGS)
+
+    def url_is_deprecated(self) -> bool:
+        settings = configmanager.read_config()
+
+        if not settings:
+            return False
+
+        return settings["providers"][0]["base_url"] != DEFAULT_SETTINGS["providers"][0]["base_url"]
+
+    def reset_provider_url(self):
+        """Reset the first provider URL to the default."""
+
+        settings = configmanager.read_config()
+
+        if not settings:
+            return
+
+        settings["providers"][0]["base_url"] = DEFAULT_SETTINGS["providers"][0]["base_url"]
+
+        configmanager.write_config(settings)
+
+    def check_provider_url(self):
+        if self.url_is_deprecated():
+            if ORStoolsDialog.url_dialog_reset_button(self.iface.mainWindow()):
+                self.reset_provider_url()

--- a/ORStools/ORStoolsPlugin.py
+++ b/ORStools/ORStoolsPlugin.py
@@ -83,7 +83,7 @@ class ORStools:
 
         QgsApplication.processingRegistry().addProvider(self.provider)
         self.dialog.initGui()
-        # starts deprecated url dialog after QGIS Main-Window opened
+        # secures that the start of deprecated url dialog happens after QGIS Main-Window opened
         iface.initializationCompleted.connect(self.check_provider_url)
 
     def unload(self) -> None:
@@ -120,7 +120,7 @@ class ORStools:
         return settings["providers"][0]["base_url"] != DEFAULT_SETTINGS["providers"][0]["base_url"]
 
     def reset_provider_url(self):
-        """Reset the first provider URL to the default."""
+        """Reset the first provider URL to the default URL."""
 
         settings = configmanager.read_config()
 

--- a/ORStools/gui/ORStoolsDialog.py
+++ b/ORStools/gui/ORStoolsDialog.py
@@ -153,6 +153,35 @@ def on_about_click(parent: QWidget) -> None:
     )
 
 
+class DeprecatedUrlDialog(QMessageBox):
+    """Dialog informing the user that the configured URL is deprecated."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setIcon(QMessageBox.Warning)
+        self.setWindowTitle(self.tr("Deprecated URL"))
+
+        self.setText(
+            self.tr(
+                "The configured ORS provider URL is deprecated.\n"
+                "Would you like to reset it to the new default URL?"
+            )
+        )
+
+        self.reset_button = self.addButton(self.tr("Reset URL"), QMessageBox.AcceptRole)
+
+        self.addButton(self.tr("Close"), QMessageBox.RejectRole)
+
+
+def url_dialog_reset_button(parent=None) -> bool:
+    """Shows the deprecated URL dialog and returns bool."""
+
+    url_dlg = DeprecatedUrlDialog(parent)
+    url_dlg.exec()
+    return url_dlg.clickedButton() == url_dlg.reset_button
+
+
 class ORStoolsDialogMain:
     """Defines all mandatory QGIS things about dialog."""
 
@@ -535,7 +564,7 @@ class ORStoolsDialog(QDialog, MAIN_WIDGET):
 
                 encoded = quote(lineEdit.text())
 
-                url = f"https://api.openrouteservice.org/geocode/search?api_key={api_key}&text={encoded}&focus.point.lat={middle.y()}&focus.point.lon={middle.x()}"
+                url = f"https://api.heigit.org/geocode/search?api_key={api_key}&text={encoded}&focus.point.lat={middle.y()}&focus.point.lon={middle.x()}"
                 error_code = request.get(QNetworkRequest(QUrl(url)))
                 if error_code == QgsBlockingNetworkRequest.ErrorCode.NoError:
                     reply = request.reply()

--- a/ORStools/gui/ORStoolsDialog.py
+++ b/ORStools/gui/ORStoolsDialog.py
@@ -159,8 +159,8 @@ class DeprecatedUrlDialog(QMessageBox):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.setIcon(QMessageBox.Warning)
-        self.setWindowTitle(self.tr("Deprecated URL"))
+        self.setIcon(QMessageBox.Icon.Warning)
+        self.setWindowTitle(self.tr("ORS Tools: Deprecated URL"))
 
         self.setText(
             self.tr(
@@ -169,9 +169,9 @@ class DeprecatedUrlDialog(QMessageBox):
             )
         )
 
-        self.reset_button = self.addButton(self.tr("Reset URL"), QMessageBox.AcceptRole)
+        self.reset_button = self.addButton(self.tr("Reset URL"), QMessageBox.ButtonRole.AcceptRole)
 
-        self.addButton(self.tr("Close"), QMessageBox.RejectRole)
+        self.addButton(self.tr("Close"), QMessageBox.ButtonRole.RejectRole)
 
 
 def url_dialog_reset_button(parent=None) -> bool:

--- a/ORStools/proc/__init__.py
+++ b/ORStools/proc/__init__.py
@@ -43,7 +43,7 @@ DEFAULT_SETTINGS = {
                 "ORS_QUOTA": "X-Ratelimit-Limit",
                 "ORS_REMAINING": "X-Ratelimit-Remaining",
             },
-            "base_url": "https://api.openrouteservice.org",
+            "base_url": "https://api.heigit.org",
             "key": "",
             "name": "openrouteservice",
             "timeout": 60,

--- a/ORStools/utils/configmanager.py
+++ b/ORStools/utils/configmanager.py
@@ -34,7 +34,7 @@ from qgis.core import QgsSettings
 
 def read_config() -> dict:
     """
-    Reads config.yml from file and returns the parsed dict.
+    Reads config and returns the parsed dict.
 
     :returns: Parsed settings dictionary.
     :rtype: dict

--- a/ORStools/utils/router.py
+++ b/ORStools/utils/router.py
@@ -35,7 +35,10 @@ def route_as_layer(task, provider, profile, optimize, directions):
     layer_out.updateFields()
 
     # if no API key is present, when ORS is selected, throw an error message
-    if not provider["key"] and provider["base_url"].startswith("https://api.openrouteservice.org"):
+    if not provider["key"] and (
+        provider["base_url"].startswith("https://api.openrouteservice.org")
+        or provider["base_url"].startswith("https://api.heigit.org")
+    ):
         raise exceptions.InvalidKey()
 
     agent = "QGIS_ORStoolsDialog"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,7 +14,7 @@ class TestCommon(unittest.TestCase):
         """Test that client retries on OverQueryLimit and eventually succeeds"""
         provider = {
             "ENV_VARS": None,
-            "base_url": "https://api.openrouteservice.org",
+            "base_url": "https://api.heigit.org",
             "key": self.api_key,
             "name": "openrouteservice",
             "timeout": 60,


### PR DESCRIPTION
read_config is now imported and called in add_default_provider_to_settings (inside of ORStoolsPlugin.py) to avoid redundant text. Later pushes: Introduction of the new default base URL (https://api.openrouteservice.org) and the deprecated URL dialog through a new class (DeprecatedUrlDialog). 